### PR TITLE
Update build-n-run-deepaas.sh

### DIFF
--- a/devops/scripts/build-n-run-deepaas.sh
+++ b/devops/scripts/build-n-run-deepaas.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # This is a helper script, which automatically installs mods and deepaas. After a successfull build, it executes deepaas.
-cd mods/ && \
-pip3 install -e . && \
-cd .. && \
 cd deepaas/ && \
 pip3 install -U . && \
+cd .. && \
+cd mods/ && \
+pip3 install -e . && \
 cd .. && \
 deepaas-run --openwhisk-detect --listen-ip 0.0.0.0 --listen-port 5000

--- a/devops/scripts/build-n-run-deepaas.sh
+++ b/devops/scripts/build-n-run-deepaas.sh
@@ -6,4 +6,4 @@ cd .. && \
 cd deepaas/ && \
 pip3 install -U . && \
 cd .. && \
-deepaas-run --listen-ip 0.0.0.0
+deepaas-run --openwhisk-detect --listen-ip 0.0.0.0 --listen-port 5000


### PR DESCRIPTION
1) deepass, mods installation order change. deepaas is installed before mods.

2) Added --openwhisk-detect and --listen-port parameters to the test script used for building and running mods by a developer.