### PR TITLE
Fix typo

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
 	"tosca": [
 		{
 			"title": "Mesos (CPU)",
-			"url": "https://raw.githubusercontent.com/indigo-dc/tosca-templates/master/deep-oc/deep-oc-mods-mesos-cpu.yml",
+			"url": "https://raw.githubusercontent.com/indigo-dc/tosca-templates/master/deep-oc/deep-oc-mods_mesos-cpu.yml",
 			"inputs": [
 				"rclone_conf",
 				"rclone_url",


### PR DESCRIPTION
you had a typo in your metadata.json. That's why your custom template didn't appear in the training dashboard.